### PR TITLE
Remove SDCCy.c patch for GBDK

### DIFF
--- a/gbdk.rb
+++ b/gbdk.rb
@@ -7,9 +7,6 @@ class Gbdk < Formula
     sha256 "7ffa454a3b99538d69fef0823bf3607177164ce2b7844d81fccedf80ed2aee12"
   end
 
-  # Apply SDCC.y changes to patched copy
-  patch :DATA
-
   def install
     ENV.deparallelize
     mkdir "sdcc/bin" # makefile forgets to make this directory
@@ -18,19 +15,3 @@ class Gbdk < Formula
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 end
-
-__END__
-diff --git a/sdcc/src/SDCCy.c b/sdcc/src/SDCCy.c
-index 65d3566..19acb34 100644
---- a/sdcc/src/SDCCy.c
-+++ b/sdcc/src/SDCCy.c
-@@ -2494,8 +2494,7 @@ case 173:
- 		     DCL_TYPE(yyvsp[0].lnk) = EEPPOINTER;
- 		     break;
- 		 default:
--		   // this could be just "constant" 
--		   // werror(W_PTR_TYPE_INVALID);
-+         ;
- 		 }
- 	     }
- 	     else 


### PR DESCRIPTION
This fixes the issue #7 for installing GBDK.