### PR TITLE
mosaic-ck: Add libxpm now that we're using libx11

### DIFF
--- a/mosaic-ck.rb
+++ b/mosaic-ck.rb
@@ -10,6 +10,7 @@ class MosaicCk < Formula
   depends_on "libpng"
   depends_on "openmotif"
   depends_on "libx11"
+  depends_on "libxpm"
 
   # Fixes build against modern libpng
   patch do


### PR DESCRIPTION
This fixes building mosaic-ck!