### PR TITLE
mksdiso: Improve formula

### DIFF
--- a/mksdiso.rb
+++ b/mksdiso.rb
@@ -7,6 +7,7 @@ class Mksdiso < Formula
 
   depends_on "cdirip"
   depends_on "cdrtools"
+  depends_on "p7zip"
 
   def install
     bin.install "bin/burncdi", "bin/mksdiso"

--- a/mksdiso.rb
+++ b/mksdiso.rb
@@ -4,6 +4,7 @@ class Mksdiso < Formula
   url "https://github.com/Nold360/mksdiso/archive/v0.9.2.tar.gz"
   sha256 "de80c68d73de03d2c111765dd82251626c681f6c5127acff77ba27befb2059f1"
   license "BSD-2-Clause"
+  head "https://github.com/Nold360/mksdiso.git"
 
   depends_on "cdirip"
   depends_on "cdrtools"

--- a/mksdiso.rb
+++ b/mksdiso.rb
@@ -10,6 +10,10 @@ class Mksdiso < Formula
   depends_on "p7zip"
 
   def install
+    pkgshare.install Dir["mksdiso/*"]
+
+    inreplace "bin/mksdiso", "DATADIR=$HOME/.mksdiso", "DATADIR=#{pkgshare}"
+
     bin.install "bin/burncdi", "bin/mksdiso"
 
     cd "src" do


### PR DESCRIPTION
This does 3 things for `mksdiso`:

- Adds the missing dependency on `p7zip`
- Installs the shared resources (default `IP.BIN` files) to `pkgshare` rather than expecting them in `~/.mksdiso`
- Adds the git url to allow building the HEAD version (which currently contains some improvements which would allow the use of `burncdi` on macOS)