### PR TITLE
mksdiso: Use ticky fork and update to v0.9.2-ticky.1

### DIFF
--- a/mksdiso.rb
+++ b/mksdiso.rb
@@ -1,10 +1,10 @@
 class Mksdiso < Formula
   desc "Create Dreamcast SDISOs from Homebrew, CDI or ISO files"
-  homepage "https://github.com/nold360/mksdiso"
-  url "https://github.com/Nold360/mksdiso/archive/v0.9.2.tar.gz"
-  sha256 "de80c68d73de03d2c111765dd82251626c681f6c5127acff77ba27befb2059f1"
+  homepage "https://github.com/ticky/mksdiso"
+  url "https://github.com/ticky/mksdiso/archive/v0.9.2-ticky.1.tar.gz"
+  sha256 "fd72dd8c46026616022868ac2033b266b7cb4d03f143fc9ba72fc298d608cca5"
   license "BSD-2-Clause"
-  head "https://github.com/Nold360/mksdiso.git"
+  head "https://github.com/ticky/mksdiso.git"
 
   depends_on "cdirip"
   depends_on "cdrtools"
@@ -18,10 +18,7 @@ class Mksdiso < Formula
     bin.install "bin/burncdi", "bin/mksdiso"
 
     cd "src" do
-      # This function is needed on macOS too
-      inreplace "isofix/isofix.h", "__linux__", "__APPLE__"
-      # Build with UPX packing off
-      system "make", "PACKER=true"
+      system "make"
 
       # The makefile's install target is more or less useless
       bin.install "binhack/bin/binhack32"


### PR DESCRIPTION
This fork includes [many proposed improvements](https://github.com/ticky/mksdiso/compare/v0.9.2...main) to macOS compatibility, which means we don't need some of the patches in this formula.