### PR TITLE
Swap Darktable to use libx11

### DIFF
--- a/darktable.rb
+++ b/darktable.rb
@@ -22,7 +22,7 @@ class Darktable < Formula
   depends_on "librsvg"
   depends_on "flickcurl"
   depends_on "lensfun"
-  depends_on :x11
+  depends_on "libx11"
 
   def install
     # The default interpolation results in -D_DARWIN_C_SOURCE being


### PR DESCRIPTION
Fixes #17, allowing the tap to be tapped again.

That being said, it doesn't compile for me, but I think that issue is unrelated.